### PR TITLE
Add Arcane Clash autobattler with hero drafting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-# Tic Tac Toe Neon
+# Arcane Clash Autobattler
 
-A simple web-based Tic Tac Toe game with a neon-themed interface and a strong AI opponent.
+A mobile-friendly HTML autobattler where you draft three heroes out of ten and watch them fight automatically with flashy effects and unique abilities.
 
-## How to Play
+## Play
+1. Open `index.html` in a modern browser.
+2. Tap or click three heroes in the roster. The **Start Battle** button unlocks once three are selected.
+3. Watch your squad face a randomly drafted enemy team. Each hero fires off its signature ability, with shields, heals, burns, stuns, and more.
+4. Hit **Reset Draft** anytime to try another lineup.
 
-1. Open `index.html` in a web browser.
-2. Click on a cell to place your `X`.
-3. The bot (`O`) will respond immediately with its move.
-4. Get three in a row horizontally, vertically, or diagonally to win.
-5. Click **Restart** to play again.
-
-The bot uses the minimax algorithm and plays optimally.
+The battlefield updates with health bars, active status effects, and a scrolling combat log so you can track the action turn by turn.

--- a/index.html
+++ b/index.html
@@ -3,26 +3,87 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tic Tac Toe Neon</title>
+    <title>Arcane Clash Autobattler</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div id="game">
-        <h1 class="title">Tic Tac Toe</h1>
-        <div id="board" class="board">
-            <div class="cell" data-index="0"></div>
-            <div class="cell" data-index="1"></div>
-            <div class="cell" data-index="2"></div>
-            <div class="cell" data-index="3"></div>
-            <div class="cell" data-index="4"></div>
-            <div class="cell" data-index="5"></div>
-            <div class="cell" data-index="6"></div>
-            <div class="cell" data-index="7"></div>
-            <div class="cell" data-index="8"></div>
+    <header class="hero">
+        <div>
+            <p class="eyebrow">Mobile-ready web autobattler</p>
+            <h1>Arcane Clash</h1>
+            <p class="lead">Draft three champions, unleash their unique abilities, and watch the auto-battle unfold with dazzling effects.</p>
         </div>
-        <p id="status" class="status"></p>
-        <button id="restart">Restart</button>
-    </div>
+        <div class="cta">
+            <button id="startButton" disabled>Start Battle</button>
+            <button id="resetButton" class="ghost">Reset Draft</button>
+            <p class="hint">Pick exactly 3 heroes from 10 to form your squad.</p>
+        </div>
+    </header>
+
+    <main class="layout">
+        <section class="panel">
+            <div class="panel-header">
+                <div>
+                    <p class="eyebrow">Hero Roster</p>
+                    <h2>Select Your Squad</h2>
+                </div>
+                <div class="badge" id="selectionCount">0 / 3 selected</div>
+            </div>
+            <div id="heroGrid" class="hero-grid"></div>
+        </section>
+
+        <section class="panel battle-panel">
+            <div class="panel-header">
+                <div>
+                    <p class="eyebrow">Arena</p>
+                    <h2>Auto Battle</h2>
+                </div>
+                <div class="round" id="roundCounter">Round 0</div>
+            </div>
+            <div class="arena">
+                <div class="team" id="playerTeam">
+                    <h3>Your Team</h3>
+                    <div class="team-list" id="playerSlots"></div>
+                </div>
+                <div class="team" id="enemyTeam">
+                    <h3>Enemy Team</h3>
+                    <div class="team-list" id="enemySlots"></div>
+                </div>
+            </div>
+            <div class="log" id="battleLog"></div>
+        </section>
+    </main>
+
+    <template id="heroCardTemplate">
+        <article class="hero-card">
+            <div class="hero-top">
+                <span class="role"></span>
+                <span class="power"></span>
+            </div>
+            <h4 class="name"></h4>
+            <p class="ability-name"></p>
+            <p class="description"></p>
+            <div class="stats">
+                <span class="stat hp"></span>
+                <span class="stat attack"></span>
+                <span class="stat speed"></span>
+            </div>
+        </article>
+    </template>
+
+    <template id="fighterTemplate">
+        <div class="fighter">
+            <div class="fighter-header">
+                <span class="f-name"></span>
+                <span class="f-role"></span>
+            </div>
+            <div class="health-bar">
+                <div class="health-fill"></div>
+            </div>
+            <div class="status-line"></div>
+        </div>
+    </template>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,127 +1,467 @@
-const boardEl = document.getElementById('board');
-const statusEl = document.getElementById('status');
-const restartBtn = document.getElementById('restart');
+const heroGrid = document.getElementById('heroGrid');
+const selectionCount = document.getElementById('selectionCount');
+const startButton = document.getElementById('startButton');
+const resetButton = document.getElementById('resetButton');
+const playerSlots = document.getElementById('playerSlots');
+const enemySlots = document.getElementById('enemySlots');
+const battleLog = document.getElementById('battleLog');
+const roundCounter = document.getElementById('roundCounter');
 
-let board = Array(9).fill(null);
-let currentPlayer = 'X';
-let gameActive = true;
+const MAX_SELECTION = 3;
+let selectedIds = [];
+let battleInterval;
+let gameState = null;
 
-const winCombos = [
-    [0, 1, 2],
-    [3, 4, 5],
-    [6, 7, 8],
-    [0, 3, 6],
-    [1, 4, 7],
-    [2, 5, 8],
-    [0, 4, 8],
-    [2, 4, 6]
+const heroes = [
+    {
+        id: 'ember',
+        name: 'Ember Knight',
+        role: 'Bruiser',
+        power: 'Flame Sweep',
+        color: '#f97316',
+        stats: { hp: 120, attack: 22, speed: 8 },
+        description: 'Sweeping slash deals splash damage and burns foes for 2 rounds.',
+        ability(actor, target, allies, enemies, log) {
+            const splashTargets = enemies.filter(e => e.alive && e.id !== target.id).slice(0, 1);
+            const damage = actor.attack;
+            dealDamage(target, damage, log, `${actor.name} cleaves ${target.name}`);
+            splashTargets.forEach(t => dealDamage(t, Math.round(damage * 0.5), log, `${actor.name} scorches ${t.name}`));
+            applyStatus(target, 'burn', 2, log, `${target.name} is burning!`);
+        }
+    },
+    {
+        id: 'storm',
+        name: 'Storm Weaver',
+        role: 'Mage',
+        power: 'Chain Lightning',
+        color: '#38bdf8',
+        stats: { hp: 90, attack: 26, speed: 10 },
+        description: 'Jolts a target then chains to another enemy for reduced damage.',
+        ability(actor, target, allies, enemies, log) {
+            dealDamage(target, actor.attack + 6, log, `${actor.name} shocks ${target.name}`);
+            const chain = enemies.find(e => e.alive && e.id !== target.id);
+            if (chain) {
+                dealDamage(chain, Math.round(actor.attack * 0.6), log, `Lightning arcs to ${chain.name}`);
+            }
+        }
+    },
+    {
+        id: 'aurora',
+        name: 'Aurora Sage',
+        role: 'Support',
+        power: 'Radiant Bloom',
+        color: '#a855f7',
+        stats: { hp: 95, attack: 16, speed: 9 },
+        description: 'Heals the lowest ally and grants a small shield.',
+        ability(actor, target, allies, enemies, log) {
+            const ally = allies.filter(a => a.alive).sort((a, b) => a.hp - b.hp)[0];
+            if (ally) {
+                heal(ally, 18, log, `${actor.name} restores ${ally.name}`);
+                addShield(ally, 12, log, `${ally.name} gains a shield`);
+            }
+        }
+    },
+    {
+        id: 'goliath',
+        name: 'Goliath',
+        role: 'Tank',
+        power: 'Earth Bulwark',
+        color: '#facc15',
+        stats: { hp: 150, attack: 18, speed: 7 },
+        description: 'Taunts foes and gains a massive shield for 2 rounds.',
+        ability(actor, target, allies, enemies, log) {
+            applyStatus(actor, 'taunt', 2, log, `${actor.name} taunts everyone!`);
+            addShield(actor, 30, log, `${actor.name} fortifies!`);
+        }
+    },
+    {
+        id: 'shade',
+        name: 'Shadowblade',
+        role: 'Assassin',
+        power: 'Night Strike',
+        color: '#64748b',
+        stats: { hp: 85, attack: 28, speed: 12 },
+        description: 'Ignores shields and has a chance to stun for 1 round.',
+        ability(actor, target, allies, enemies, log) {
+            dealDamage(target, actor.attack + 8, log, `${actor.name} strikes from the shadows`, true);
+            if (Math.random() < 0.35) {
+                applyStatus(target, 'stun', 1, log, `${target.name} is stunned!`);
+            }
+        }
+    },
+    {
+        id: 'frost',
+        name: 'Frost Archer',
+        role: 'Ranger',
+        power: 'Piercing Shot',
+        color: '#60a5fa',
+        stats: { hp: 100, attack: 20, speed: 11 },
+        description: 'High-speed shot that slows enemies (reduces speed) for 2 rounds.',
+        ability(actor, target, allies, enemies, log) {
+            dealDamage(target, actor.attack, log, `${actor.name} pierces ${target.name}`);
+            applyStatus(target, 'slow', 2, log, `${target.name} is slowed.`);
+        }
+    },
+    {
+        id: 'verdant',
+        name: 'Verdant Warden',
+        role: 'Druid',
+        power: 'Nature Pulse',
+        color: '#22c55e',
+        stats: { hp: 110, attack: 17, speed: 9 },
+        description: 'Heals allies over time and poisons enemies for chip damage.',
+        ability(actor, target, allies, enemies, log) {
+            allies.filter(a => a.alive).forEach(a => heal(a, 8, log, `${actor.name} rejuvenates ${a.name}`));
+            enemies.filter(e => e.alive).forEach(e => applyStatus(e, 'burn', 2, log, `${e.name} is poisoned`));
+        }
+    },
+    {
+        id: 'celest',
+        name: 'Celestial Monk',
+        role: 'Monk',
+        power: 'Chi Flow',
+        color: '#38f3ab',
+        stats: { hp: 105, attack: 19, speed: 10 },
+        description: 'If no allies are down, deals bonus damage; otherwise revives 1 ally with low HP.',
+        ability(actor, target, allies, enemies, log) {
+            const fallen = allies.find(a => !a.alive);
+            if (fallen) {
+                revive(fallen, 35, log, `${actor.name} revives ${fallen.name}`);
+            } else {
+                dealDamage(target, actor.attack + 10, log, `${actor.name} unleashes chi`);
+            }
+        }
+    },
+    {
+        id: 'emberfox',
+        name: 'Emberfox',
+        role: 'Trickster',
+        power: 'Foxfire Mirage',
+        color: '#fb7185',
+        stats: { hp: 92, attack: 18, speed: 13 },
+        description: 'Creates mirages increasing evasion; counters when shielded.',
+        ability(actor, target, allies, enemies, log) {
+            applyStatus(actor, 'evade', 2, log, `${actor.name} becomes elusive.`);
+            addShield(actor, 10, log, `${actor.name} weaves a mirage shield`);
+        }
+    },
+    {
+        id: 'voltage',
+        name: 'Voltage Titan',
+        role: 'Juggernaut',
+        power: 'Overcharge',
+        color: '#f472b6',
+        stats: { hp: 140, attack: 21, speed: 8 },
+        description: 'Charges for extra damage next attack and gains a shield.',
+        ability(actor, target, allies, enemies, log) {
+            applyStatus(actor, 'charged', 2, log, `${actor.name} is overcharged!`);
+            addShield(actor, 16, log, `${actor.name} crackles with power`);
+        }
+    }
 ];
 
-boardEl.addEventListener('click', handleCellClick);
-restartBtn.addEventListener('click', startGame);
-
-function startGame() {
-    board = Array(9).fill(null);
-    currentPlayer = 'X';
-    gameActive = true;
-    statusEl.textContent = '';
-    Array.from(boardEl.children).forEach(cell => {
-        cell.textContent = '';
-        cell.classList.remove('win');
-    });
-    if (currentPlayer === 'O') botMove();
+function createCard(hero) {
+    const template = document.getElementById('heroCardTemplate');
+    const card = template.content.firstElementChild.cloneNode(true);
+    card.querySelector('.role').textContent = hero.role;
+    card.querySelector('.power').textContent = hero.power;
+    card.querySelector('.name').textContent = hero.name;
+    card.querySelector('.ability-name').textContent = hero.power;
+    card.querySelector('.description').textContent = hero.description;
+    card.querySelector('.hp').textContent = `HP ${hero.stats.hp}`;
+    card.querySelector('.attack').textContent = `ATK ${hero.stats.attack}`;
+    card.querySelector('.speed').textContent = `SPD ${hero.stats.speed}`;
+    card.style.borderColor = hero.color;
+    card.addEventListener('click', () => toggleSelect(hero.id, card));
+    return card;
 }
 
-function handleCellClick(e) {
-    const index = e.target.dataset.index;
-    if (index === undefined || !gameActive || board[index]) return;
-
-    makeMove(index, currentPlayer);
-    if (!checkGameEnd()) {
-        currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
-        botMove();
-    }
+function renderRoster() {
+    heroes.forEach(hero => heroGrid.appendChild(createCard(hero)));
 }
 
-function makeMove(index, player) {
-    board[index] = player;
-    boardEl.children[index].textContent = player;
-}
-
-function checkGameEnd() {
-    for (const combo of winCombos) {
-        const [a, b, c] = combo;
-        if (board[a] && board[a] === board[b] && board[a] === board[c]) {
-            combo.forEach(i => boardEl.children[i].classList.add('win'));
-            statusEl.textContent = `${board[a]} wins!`;
-            gameActive = false;
-            return true;
-        }
-    }
-    if (board.every(cell => cell)) {
-        statusEl.textContent = 'Draw!';
-        gameActive = false;
-        return true;
-    }
-    return false;
-}
-
-function botMove() {
-    const best = minimax(board.slice(), 'O');
-    makeMove(best.index, 'O');
-    if (!checkGameEnd()) currentPlayer = 'X';
-}
-
-function minimax(newBoard, player) {
-    const avail = newBoard.map((v, i) => v ? null : i).filter(i => i !== null);
-
-    if (winning(newBoard, 'X')) return {score: -10};
-    if (winning(newBoard, 'O')) return {score: 10};
-    if (avail.length === 0) return {score: 0};
-
-    const moves = [];
-    for (const i of avail) {
-        const move = {index: i};
-        newBoard[i] = player;
-
-        if (player === 'O') {
-            const result = minimax(newBoard, 'X');
-            move.score = result.score;
-        } else {
-            const result = minimax(newBoard, 'O');
-            move.score = result.score;
-        }
-
-        newBoard[i] = null;
-        moves.push(move);
-    }
-
-    let bestMove;
-    if (player === 'O') {
-        let bestScore = -Infinity;
-        for (const move of moves) {
-            if (move.score > bestScore) {
-                bestScore = move.score;
-                bestMove = move;
-            }
-        }
+function toggleSelect(id, card) {
+    if (selectedIds.includes(id)) {
+        selectedIds = selectedIds.filter(h => h !== id);
+        card.classList.remove('selected');
     } else {
-        let bestScore = Infinity;
-        for (const move of moves) {
-            if (move.score < bestScore) {
-                bestScore = move.score;
-                bestMove = move;
-            }
-        }
+        if (selectedIds.length >= MAX_SELECTION) return;
+        selectedIds.push(id);
+        card.classList.add('selected');
     }
-    return bestMove;
+    selectionCount.textContent = `${selectedIds.length} / ${MAX_SELECTION} selected`;
+    startButton.disabled = selectedIds.length !== MAX_SELECTION;
 }
 
-function winning(board, player) {
-    return winCombos.some(combo => {
-        const [a, b, c] = combo;
-        return board[a] === player && board[b] === player && board[c] === player;
-    });
+function resetDraft() {
+    selectedIds = [];
+    selectionCount.textContent = `0 / ${MAX_SELECTION} selected`;
+    startButton.disabled = true;
+    document.querySelectorAll('.hero-card').forEach(c => c.classList.remove('selected'));
+    clearBattlefield();
 }
 
-startGame();
+function clearBattlefield() {
+    playerSlots.innerHTML = '';
+    enemySlots.innerHTML = '';
+    battleLog.innerHTML = '';
+    roundCounter.textContent = 'Round 0';
+    if (battleInterval) clearTimeout(battleInterval);
+    gameState = null;
+}
+
+function pickEnemyTeam() {
+    const pool = heroes.filter(h => !selectedIds.includes(h.id));
+    const shuffled = pool.sort(() => Math.random() - 0.5);
+    return shuffled.slice(0, MAX_SELECTION).map(copyHeroState);
+}
+
+function copyHeroState(hero) {
+    return {
+        ...hero,
+        hp: hero.stats.hp,
+        maxHp: hero.stats.hp,
+        attack: hero.stats.attack,
+        speed: hero.stats.speed,
+        alive: true,
+        status: { burn: 0, shield: 0, regen: 0, stun: 0, taunt: 0, slow: 0, evade: 0, charged: 0 }
+    };
+}
+
+function startBattle() {
+    const playerTeam = selectedIds.map(id => heroes.find(h => h.id === id)).map(copyHeroState);
+    const enemyTeam = pickEnemyTeam();
+    gameState = { playerTeam, enemyTeam, round: 1, running: true };
+    renderTeams(playerTeam, enemyTeam);
+    logEvent('Battle starts!');
+    nextRound();
+}
+
+function renderTeams(playerTeam, enemyTeam) {
+    playerSlots.innerHTML = '';
+    enemySlots.innerHTML = '';
+    playerTeam.forEach(hero => playerSlots.appendChild(createFighter(hero)));
+    enemyTeam.forEach(hero => enemySlots.appendChild(createFighter(hero)));
+}
+
+function createFighter(hero) {
+    const template = document.getElementById('fighterTemplate');
+    const el = template.content.firstElementChild.cloneNode(true);
+    el.dataset.id = hero.id;
+    el.querySelector('.f-name').textContent = hero.name;
+    el.querySelector('.f-role').textContent = hero.role;
+    updateFighter(el, hero);
+    return el;
+}
+
+function updateFighter(el, hero) {
+    const hpPercent = Math.max(0, Math.round((hero.hp / hero.maxHp) * 100));
+    const healthFill = el.querySelector('.health-fill');
+    healthFill.style.width = `${hpPercent}%`;
+    healthFill.style.background = `linear-gradient(90deg, ${hero.color}, #16a34a)`;
+    el.querySelector('.status-line').innerHTML = renderStatuses(hero);
+    if (!hero.alive) {
+        el.classList.add('fainted');
+        el.style.opacity = 0.4;
+    }
+}
+
+function renderStatuses(hero) {
+    const statuses = [];
+    if (hero.status.burn > 0) statuses.push(`<span class="status-pill burn">Burn ${hero.status.burn}</span>`);
+    if (hero.status.regen > 0) statuses.push(`<span class="status-pill regen">Regen ${hero.status.regen}</span>`);
+    if (hero.status.shield > 0) statuses.push(`<span class="status-pill shield">Shield ${hero.status.shield}</span>`);
+    if (hero.status.stun > 0) statuses.push(`<span class="status-pill stun">Stun</span>`);
+    if (hero.status.evade > 0) statuses.push(`<span class="status-pill">Evade ${hero.status.evade}</span>`);
+    if (hero.status.taunt > 0) statuses.push(`<span class="status-pill">Taunt</span>`);
+    if (hero.status.slow > 0) statuses.push(`<span class="status-pill">Slow ${hero.status.slow}</span>`);
+    if (hero.status.charged > 0) statuses.push(`<span class="status-pill">Charged</span>`);
+    return statuses.join('');
+}
+
+function logEvent(text) {
+    const entry = document.createElement('div');
+    entry.className = 'log-entry';
+    entry.innerHTML = text;
+    battleLog.appendChild(entry);
+    battleLog.scrollTop = battleLog.scrollHeight;
+}
+
+function getFighterElement(hero) {
+    return document.querySelector(`.fighter[data-id="${hero.id}"]`);
+}
+
+function animateHit(hero) {
+    const el = getFighterElement(hero);
+    if (!el) return;
+    el.classList.add('hit');
+    setTimeout(() => el.classList.remove('hit'), 400);
+}
+
+function animateHeal(hero) {
+    const el = getFighterElement(hero);
+    if (!el) return;
+    el.classList.add('heal');
+    setTimeout(() => el.classList.remove('heal'), 800);
+}
+
+function nextRound() {
+    if (!gameState || !gameState.running) return;
+    roundCounter.textContent = `Round ${gameState.round}`;
+
+    const order = [...gameState.playerTeam, ...gameState.enemyTeam]
+        .filter(h => h.alive)
+        .sort((a, b) => (b.speed - (b.status.slow ? 2 : 0)) - (a.speed - (a.status.slow ? 2 : 0)));
+
+    executeTurn(order, 0);
+}
+
+function executeTurn(order, idx) {
+    if (!gameState || !gameState.running) return;
+    if (idx >= order.length) {
+        gameState.round += 1;
+        battleInterval = setTimeout(nextRound, 700);
+        return;
+    }
+
+    const actor = order[idx];
+    if (!actor.alive) {
+        executeTurn(order, idx + 1);
+        return;
+    }
+
+    processStatuses(actor);
+    if (!actor.alive) {
+        executeTurn(order, idx + 1);
+        return;
+    }
+
+    const targetTeam = gameState.playerTeam.includes(actor) ? gameState.enemyTeam : gameState.playerTeam;
+    const allies = gameState.playerTeam.includes(actor) ? gameState.playerTeam : gameState.enemyTeam;
+
+    if (actor.status.stun > 0) {
+        logEvent(`<strong>${actor.name}</strong> is stunned and misses the turn.`);
+        actor.status.stun -= 1;
+        executeTurn(order, idx + 1);
+        return;
+    }
+
+    const taunter = targetTeam.find(t => t.alive && t.status.taunt > 0);
+    const target = taunter || targetTeam.find(t => t.alive);
+    if (!target) {
+        finishBattle();
+        return;
+    }
+
+    const actorEl = getFighterElement(actor);
+    if (actorEl) actorEl.classList.add('active');
+
+    setTimeout(() => {
+        actor.ability(actor, target, allies, targetTeam, logEvent);
+        const bonus = actor.status.charged > 0 ? 8 : 0;
+        if (bonus && target.alive) {
+            dealDamage(target, bonus, logEvent, `${actor.name} overcharge bonus`);
+            actor.status.charged -= 1;
+        }
+        actor.status.taunt = Math.max(0, actor.status.taunt - 1);
+        actor.status.evade = Math.max(0, actor.status.evade - 1);
+        actor.status.slow = Math.max(0, actor.status.slow - 1);
+        if (!checkVictory()) {
+            if (actorEl) actorEl.classList.remove('active');
+            battleInterval = setTimeout(() => executeTurn(order, idx + 1), 550);
+        }
+    }, 250);
+}
+
+function processStatuses(hero) {
+    if (!hero.alive) return;
+    if (hero.status.burn > 0) {
+        dealDamage(hero, 6, logEvent, `${hero.name} suffers burn.`);
+        hero.status.burn -= 1;
+    }
+    if (!hero.alive) return;
+    if (hero.status.regen > 0) {
+        heal(hero, 8, logEvent, `${hero.name} regenerates.`);
+        hero.status.regen -= 1;
+    }
+}
+
+function checkVictory() {
+    const playerAlive = gameState.playerTeam.some(h => h.alive);
+    const enemyAlive = gameState.enemyTeam.some(h => h.alive);
+    if (playerAlive && enemyAlive) return false;
+    finishBattle(playerAlive);
+    return true;
+}
+
+function finishBattle(playerWon) {
+    gameState.running = false;
+    if (playerWon === undefined) {
+        playerWon = gameState.playerTeam.some(h => h.alive);
+    }
+    const message = playerWon ? 'You win! 🎉' : 'Defeat... try a new draft.';
+    logEvent(`<strong>${message}</strong>`);
+    startButton.disabled = false;
+}
+
+function dealDamage(target, amount, log, text, ignoreShield = false) {
+    if (!target.alive) return;
+    if (target.status.evade > 0 && Math.random() < 0.4) {
+        target.status.evade -= 1;
+        log(`${target.name} evades the strike!`);
+        return;
+    }
+    let remaining = amount;
+    if (!ignoreShield && target.status.shield > 0) {
+        const absorbed = Math.min(target.status.shield, remaining);
+        target.status.shield -= absorbed;
+        remaining -= absorbed;
+    }
+    target.hp -= remaining;
+    if (target.hp <= 0) {
+        target.hp = 0;
+        target.alive = false;
+        log(`${text} for <span class="damage">${amount}</span> dmg. ${target.name} is down!`);
+    } else {
+        log(`${text} for <span class="damage">${amount}</span> dmg.`);
+    }
+    animateHit(target);
+    updateFighter(getFighterElement(target), target);
+}
+
+function heal(target, amount, log, text) {
+    if (!target.alive) return;
+    target.hp = Math.min(target.maxHp, target.hp + amount);
+    log(`${text} for <span class="heal">${amount}</span> HP.`);
+    animateHeal(target);
+    updateFighter(getFighterElement(target), target);
+}
+
+function addShield(target, value, log, text) {
+    target.status.shield += value;
+    log(text);
+    updateFighter(getFighterElement(target), target);
+}
+
+function applyStatus(target, status, duration, log, text) {
+    target.status[status] = Math.max(target.status[status], duration);
+    log(text);
+    updateFighter(getFighterElement(target), target);
+}
+
+function revive(target, percent, log, text) {
+    if (target.alive) return;
+    target.alive = true;
+    target.hp = Math.round((percent / 100) * target.maxHp);
+    log(text);
+    updateFighter(getFighterElement(target), target);
+}
+
+startButton.addEventListener('click', () => {
+    startButton.disabled = true;
+    clearBattlefield();
+    startBattle();
+});
+
+resetButton.addEventListener('click', resetDraft);
+renderRoster();

--- a/style.css
+++ b/style.css
@@ -1,3 +1,19 @@
+:root {
+    --bg: radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.25), transparent 30%),
+          radial-gradient(circle at 80% 0%, rgba(16, 185, 129, 0.25), transparent 25%),
+          #0b1021;
+    --card: rgba(255, 255, 255, 0.04);
+    --border: rgba(255, 255, 255, 0.08);
+    --accent: #7c3aed;
+    --accent-2: #22d3ee;
+    --text: #f8fafc;
+    --muted: #94a3b8;
+    --danger: #ef4444;
+    --success: #22c55e;
+    --warning: #f59e0b;
+    --glow: 0 0 20px rgba(124, 58, 237, 0.45);
+}
+
 * {
     box-sizing: border-box;
     margin: 0;
@@ -5,67 +21,302 @@
 }
 
 body {
-    font-family: Arial, Helvetica, sans-serif;
-    background: #0f0f0f;
-    color: #e0e0e0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
+    font-family: "Inter", system-ui, -apple-system, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    padding: 20px;
 }
 
-#game {
-    text-align: center;
+h1, h2, h3, h4 {
+    letter-spacing: 0.4px;
 }
 
-.title {
-    margin-bottom: 20px;
-    color: #0ff;
-    text-shadow: 0 0 10px #0ff, 0 0 20px #0ff;
-}
-
-.board {
+.hero {
     display: grid;
-    grid-template-columns: repeat(3, 100px);
-    grid-template-rows: repeat(3, 100px);
-    gap: 10px;
-    margin-bottom: 20px;
+    grid-template-columns: 1fr auto;
+    gap: 16px;
+    padding: 24px;
+    background: linear-gradient(135deg, rgba(124, 58, 237, 0.2), rgba(34, 211, 238, 0.2));
+    border: 1px solid var(--border);
+    border-radius: 18px;
+    box-shadow: var(--glow);
+    margin-bottom: 18px;
 }
 
-.cell {
-    width: 100px;
-    height: 100px;
+.hero h1 {
+    font-size: 32px;
+    margin-bottom: 6px;
+}
+
+.lead {
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    font-size: 12px;
+    letter-spacing: 2px;
+    color: var(--accent-2);
+    margin-bottom: 4px;
+}
+
+.cta {
     display: flex;
-    justify-content: center;
-    align-items: center;
-    font-size: 48px;
-    color: #fff;
-    border: 2px solid #0ff;
-    box-shadow: 0 0 5px #0ff, 0 0 15px #0ff inset;
-    cursor: pointer;
-    transition: transform 0.2s;
-}
-
-.cell:hover {
-    transform: scale(1.1);
-}
-
-.status {
-    height: 24px;
-    margin-bottom: 10px;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
 }
 
 button {
-    padding: 10px 20px;
+    background: linear-gradient(135deg, #7c3aed, #22d3ee);
     border: none;
-    background: #0ff;
-    color: #000;
-    font-size: 16px;
+    padding: 12px 18px;
+    border-radius: 12px;
+    color: white;
+    font-weight: 700;
     cursor: pointer;
-    box-shadow: 0 0 10px #0ff;
-    transition: background 0.3s;
+    transition: transform 0.15s ease, filter 0.15s ease;
+    box-shadow: var(--glow);
 }
 
-button:hover {
-    background: #0cc;
+button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    filter: grayscale(0.7);
+}
+
+button:hover:not(:disabled) {
+    transform: translateY(-2px);
+}
+
+button.ghost {
+    background: transparent;
+    border: 1px solid var(--border);
+    box-shadow: none;
+}
+
+.hint {
+    color: var(--muted);
+    font-size: 14px;
+}
+
+.layout {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 18px;
+}
+
+.panel {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 18px;
+    backdrop-filter: blur(6px);
+    box-shadow: 0 10px 40px rgba(0,0,0,0.25);
+}
+
+.panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.badge, .round {
+    padding: 8px 12px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--border);
+    font-weight: 700;
+    color: var(--accent-2);
+}
+
+.hero-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 12px;
+}
+
+.hero-card {
+    padding: 14px;
+    border-radius: 14px;
+    background: rgba(255,255,255,0.03);
+    border: 1px solid var(--border);
+    transition: transform 0.2s ease, border 0.2s ease, box-shadow 0.2s ease;
+    position: relative;
+    cursor: pointer;
+}
+
+.hero-card.selected {
+    border-color: var(--accent-2);
+    box-shadow: var(--glow);
+}
+
+.hero-card:hover {
+    transform: translateY(-4px);
+}
+
+.hero-top {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 6px;
+    color: var(--muted);
+    font-size: 13px;
+}
+
+.hero-card .name {
+    font-size: 18px;
+    margin-bottom: 4px;
+}
+
+.hero-card .ability-name {
+    color: var(--accent-2);
+    font-weight: 700;
+}
+
+.hero-card .description {
+    color: var(--muted);
+    font-size: 14px;
+    line-height: 1.4;
+    margin: 6px 0;
+}
+
+.stats {
+    display: flex;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--muted);
+}
+
+.stat::before { content: ""; display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 6px; }
+.stat.hp::before { background: var(--success); }
+.stat.attack::before { background: var(--accent); }
+.stat.speed::before { background: var(--accent-2); }
+
+.battle-panel .arena {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.team {
+    background: rgba(255,255,255,0.02);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+}
+
+.team h3 {
+    margin-bottom: 8px;
+    color: var(--muted);
+}
+
+.team-list {
+    display: grid;
+    gap: 10px;
+}
+
+.fighter {
+    background: rgba(255,255,255,0.03);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 10px;
+    position: relative;
+    overflow: hidden;
+}
+
+.fighter::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(124, 58, 237, 0.15), transparent 40%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.fighter.active::after {
+    opacity: 1;
+}
+
+.fighter-header {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 6px;
+}
+
+.health-bar {
+    background: rgba(255,255,255,0.07);
+    border-radius: 10px;
+    overflow: hidden;
+    height: 12px;
+    border: 1px solid var(--border);
+}
+
+.health-fill {
+    height: 100%;
+    width: 100%;
+    background: linear-gradient(90deg, #22c55e, #16a34a);
+    transition: width 0.3s ease, background 0.3s ease;
+}
+
+.status-line {
+    margin-top: 6px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-height: 20px;
+}
+
+.status-pill {
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    color: white;
+}
+
+.status-pill.burn { background: rgba(239, 68, 68, 0.2); border: 1px solid rgba(239, 68, 68, 0.4); }
+.status-pill.shield { background: rgba(59, 130, 246, 0.2); border: 1px solid rgba(59, 130, 246, 0.5); }
+.status-pill.regen { background: rgba(34, 197, 94, 0.2); border: 1px solid rgba(34, 197, 94, 0.5); }
+.status-pill.stun { background: rgba(245, 158, 11, 0.2); border: 1px solid rgba(245, 158, 11, 0.5); }
+
+.log {
+    background: rgba(0,0,0,0.3);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    max-height: 260px;
+    overflow-y: auto;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.log-entry { margin-bottom: 6px; }
+.log-entry strong { color: var(--accent-2); }
+.log-entry span.damage { color: var(--danger); }
+.log-entry span.heal { color: var(--success); }
+
+@keyframes swing {
+    0% { transform: translateX(0); }
+    25% { transform: translateX(-6px); }
+    50% { transform: translateX(6px); }
+    75% { transform: translateX(-2px); }
+    100% { transform: translateX(0); }
+}
+
+@keyframes pulseGlow {
+    0% { box-shadow: 0 0 0px rgba(34, 211, 238, 0.2); }
+    50% { box-shadow: 0 0 20px rgba(34, 211, 238, 0.4); }
+    100% { box-shadow: 0 0 0px rgba(34, 211, 238, 0.2); }
+}
+
+.fighter.hit { animation: swing 0.4s ease; }
+.fighter.heal { animation: pulseGlow 0.8s ease; }
+
+@media (max-width: 900px) {
+    .layout { grid-template-columns: 1fr; }
+    .hero { grid-template-columns: 1fr; }
+    .cta { align-items: flex-start; }
 }


### PR DESCRIPTION
## Summary
- replace tic-tac-toe UI with Arcane Clash autobattler including hero drafting and battle log
- add responsive neon-inspired styling and combat animations for hits, heals, and status effects
- implement hero abilities, shields, stuns, burns, and automated turn-based combat logic

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ced0a19083288c0de58c86922faa)